### PR TITLE
Button groups: allowing grouped buttons to have a "disabled" attribute.

### DIFF
--- a/components/ButtonGroup.jsx
+++ b/components/ButtonGroup.jsx
@@ -13,7 +13,8 @@ var ButtonGroup = React.createClass({
 		buttons: React.PropTypes.arrayOf(React.PropTypes.shape({
 			value: React.PropTypes.any.isRequired,
 			content: React.PropTypes.node,
-			title: React.PropTypes.string
+			title: React.PropTypes.string,
+			disabled: React.PropTypes.bool
 			})).isRequired,
 		onClick: React.PropTypes.func.isRequired,
 		className: React.PropTypes.string

--- a/components/ButtonGroup.jsx
+++ b/components/ButtonGroup.jsx
@@ -35,7 +35,7 @@ var ButtonGroup = React.createClass({
 						onClick={this._handleClick}
 						text={button.content || "" + button.value}
 						className="button-group-button"
-						disabled={!!this.props.disabled}
+						disabled={!!button.disabled}
 					/>
 			);
 		}, this);

--- a/components/ButtonGroup.jsx
+++ b/components/ButtonGroup.jsx
@@ -35,6 +35,7 @@ var ButtonGroup = React.createClass({
 						onClick={this._handleClick}
 						text={button.content || "" + button.value}
 						className="button-group-button"
+						disabled={!!this.props.disabled}
 					/>
 			);
 		}, this);


### PR DESCRIPTION
Required by https://github.com/Quartz/atlas-chartbuilder/pull/31 .